### PR TITLE
feat: Implement search and tag filtering for items

### DIFF
--- a/openspec/changes/implement-search-filtering/.openspec.yaml
+++ b/openspec/changes/implement-search-filtering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-05

--- a/openspec/changes/implement-search-filtering/design.md
+++ b/openspec/changes/implement-search-filtering/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The HowCanI application stores FAQ items in SQLite with TEXT (UUID) primary keys. Items have questions, answers, and tag associations via a junction table. The current `GET /api/:username/items` endpoint supports pagination (`limit`/`offset`) but no search or filtering. The search-filtering spec requires FTS5 full-text search and tag-based AND filtering.
+
+Key constraint: item IDs are UUIDs (TEXT), not INTEGER. The spec's FTS5 schema uses `content_rowid=id` which requires an INTEGER column. We need to adapt the FTS5 approach.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Full-text search across item question and answer fields via FTS5
+- Tag-based AND filtering on the items list endpoint
+- Combined search + tag filtering with pagination
+- Relevance-based ranking (BM25) when searching
+- Backfill existing items into FTS5 index on migration
+
+**Non-Goals:**
+- Frontend UI components (separate change)
+- Fuzzy/typo-tolerant search (FTS5 prefix matching is sufficient)
+- Search result highlighting/snippets
+- Query result caching (premature for single-user home lab)
+
+## Decisions
+
+### 1. FTS5 with external content, using SQLite rowid
+
+**Decision:** Use FTS5 external content table referencing the items table's implicit SQLite `rowid` (not the UUID `id` column).
+
+**Rationale:** FTS5's `content_rowid` must reference an INTEGER column. Every SQLite table has an implicit integer `rowid`. We use `content=items, content_rowid=rowid` and join via `items.rowid = items_fts.rowid`.
+
+**Alternative considered:** Standalone FTS5 table (no `content=` option) with manual sync. Rejected because it doubles storage and the trigger-based sync is more fragile without the built-in content table mechanism.
+
+### 2. Tag filtering via HAVING COUNT with subquery
+
+**Decision:** Use a single query with GROUP BY/HAVING to implement AND filtering for multiple tags, rather than multiple JOINs per tag.
+
+```sql
+SELECT items.* FROM items
+JOIN item_tags ON items.id = item_tags.item_id
+JOIN tags ON item_tags.tag_id = tags.id
+WHERE items.user_id = ? AND tags.name IN (?, ?)
+GROUP BY items.id
+HAVING COUNT(DISTINCT tags.id) = ?
+```
+
+**Rationale:** Scales to any number of tags without dynamically generating JOIN clauses. The HAVING COUNT approach is standard SQL and performs well with existing indexes.
+
+**Alternative considered:** Dynamic multi-JOIN approach (one JOIN per tag). Rejected because it requires SQL string building and becomes unwieldy with many tags.
+
+### 3. Extend existing ItemRepository instead of new search module
+
+**Decision:** Add `searchItems()` method to `ItemRepository` rather than creating a separate search module.
+
+**Rationale:** The search is a query mode for items, not a separate domain. Keeping it in ItemRepository maintains the existing pattern. The method accepts optional `search` and `tags` parameters alongside pagination.
+
+**Alternative considered:** Separate `SearchRepository` or `search.ts` module as suggested in the spec's implementation notes. Rejected because the query is fundamentally an item query with additional WHERE clauses, not a separate concern.
+
+### 4. FTS5 query sanitization
+
+**Decision:** Sanitize user search input by escaping FTS5 special characters and appending `*` for prefix matching.
+
+**Rationale:** FTS5 MATCH syntax has special characters (`AND`, `OR`, `NOT`, `"`, `*`, etc.). Raw user input could cause query errors or unintended behavior. We escape special chars and wrap terms for safe prefix matching.
+
+### 5. Migration with backfill
+
+**Decision:** Migration version 5 creates FTS5 table, triggers, and backfills existing items in a single migration.
+
+**Rationale:** After creating the virtual table and triggers, we need to populate it with existing data. This is a one-time operation that runs during the migration transaction.
+
+## Risks / Trade-offs
+
+**FTS5 rowid coupling** - Using implicit SQLite rowid means the FTS5 index is tightly coupled to SQLite internals. Mitigation: This is standard SQLite usage; rowid is stable and documented.
+
+**Search input edge cases** - Users could input strings that break FTS5 syntax even after sanitization. Mitigation: Wrap sanitized input in quotes, fall back to LIKE query if FTS5 MATCH fails.
+
+**Migration on large databases** - Backfilling FTS5 index scans all items. Mitigation: This is a home lab app with modest data; backfill will be fast. The migration runs in a transaction.
+
+**Tag filter performance with many tags** - GROUP BY/HAVING on large item sets could be slow. Mitigation: Existing indexes on `item_tags(item_id)`, `item_tags(tag_id)`, and `items(user_id)` cover the query. For a home lab scale this is more than sufficient.

--- a/openspec/changes/implement-search-filtering/proposal.md
+++ b/openspec/changes/implement-search-filtering/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The item listing endpoint (`GET /api/:username/items`) currently returns all items with basic pagination but no way to search or filter. Users need to find specific FAQ entries by text content and narrow results by tags. The search-filtering spec defines these capabilities using SQLite FTS5 for full-text search and tag-based AND filtering.
+
+## What Changes
+
+- Add SQLite FTS5 virtual table (`items_fts`) for indexing item question and answer fields
+- Add database migration with FTS5 table, sync triggers (insert/update/delete), and backfill of existing items
+- Extend `ItemRepository` with `search()` method supporting FTS5 queries, tag filtering, and combined search+filter
+- Extend `ItemService.listItems()` to accept optional `search` and `tags` filter parameters
+- Update `GET /api/:username/items` route to parse `search` and `tags` query parameters and pass them through
+- Return active filters in response: `{ items, total, filters: { search, tags } }`
+
+## Capabilities
+
+### New Capabilities
+
+(none - search-filtering spec already exists)
+
+### Modified Capabilities
+
+- `search-filtering`: Implementing the full-text search and tag filtering requirements defined in the existing spec
+- `item-management`: Extending the item listing endpoint to support search and tag query parameters
+
+## Impact
+
+**Affected code:**
+- `src/server/db/migrations.ts` - New migration (version 5) for FTS5 table and triggers
+- `src/server/repositories/item.repository.ts` - Add search/filter query methods
+- `src/server/services/item.service.ts` - Extend listItems with search/filter params
+- `src/server/routes/item.routes.ts` - Parse search/tags query params
+- New test files for search and filter functionality
+
+**Dependencies:**
+- SQLite FTS5 extension (built into Bun's SQLite)
+- No new npm packages needed
+
+**APIs:**
+- `GET /api/:username/items` gains `?search=text&tags=tag1,tag2` query parameters
+- Response shape adds `filters` object

--- a/openspec/changes/implement-search-filtering/specs/item-management/spec.md
+++ b/openspec/changes/implement-search-filtering/specs/item-management/spec.md
@@ -1,0 +1,68 @@
+## MODIFIED Requirements
+
+### Requirement: Read Item
+
+Anyone MUST be able to view items without authentication.
+
+#### Scenario: List all items for user
+
+**Given** user "john" has multiple items
+
+**When** GET to `/api/john/items`
+
+**Then** the system should:
+- Return status `StatusCodes.OK`
+- Return paginated list of items
+- Include item previews (truncated answers if needed)
+- Include tag information
+- Default pagination: 50 items per page
+- No authentication required
+
+#### Scenario: List items with pagination
+
+**Given** user "john" has 75 items
+
+**When** GET to `/api/john/items?limit=20&offset=40`
+
+**Then** the system should:
+- Return status `StatusCodes.OK`
+- Return items 41-60
+- Include total count: 75
+- Enable pagination UI
+
+#### Scenario: List items with search filter
+
+**Given** user "john" has items with various content
+
+**When** GET to `/api/john/items?search=deploy`
+
+**Then** the system SHALL:
+- Return only items matching "deploy" via FTS5 full-text search
+- Order results by BM25 relevance ranking
+- Include `filters` object in response: `{ search: "deploy", tags: null }`
+- No authentication required
+
+#### Scenario: List items with tag filter
+
+**Given** user "john" has items with various tags
+
+**When** GET to `/api/john/items?tags=bun,typescript`
+
+**Then** the system SHALL:
+- Return only items having both "bun" AND "typescript" tags
+- Order results by `created_at DESC`
+- Include `filters` object in response: `{ search: null, tags: ["bun", "typescript"] }`
+- No authentication required
+
+#### Scenario: List items with combined search and tag filter
+
+**Given** user "john" has items with various content and tags
+
+**When** GET to `/api/john/items?search=deploy&tags=bun&limit=20&offset=0`
+
+**Then** the system SHALL:
+- Return items matching "deploy" AND having "bun" tag
+- Order results by BM25 relevance ranking
+- Apply pagination to filtered results
+- Include `filters` object: `{ search: "deploy", tags: ["bun"] }`
+- Include accurate `total` count of all matching items

--- a/openspec/changes/implement-search-filtering/specs/search-filtering/spec.md
+++ b/openspec/changes/implement-search-filtering/specs/search-filtering/spec.md
@@ -1,0 +1,121 @@
+## MODIFIED Requirements
+
+### Requirement: SQLite FTS5 Integration
+
+The system MUST use SQLite FTS5 for efficient full-text search.
+
+#### Scenario: FTS5 virtual table for items
+
+- **WHEN** database migration version 5 runs
+- **THEN** the system SHALL:
+  - Create FTS5 virtual table `items_fts` with `content=items, content_rowid=rowid`
+  - Index `question` and `answer` columns
+  - Create AFTER INSERT trigger on `items` to insert into `items_fts`
+  - Create AFTER UPDATE trigger on `items` to update `items_fts`
+  - Create AFTER DELETE trigger on `items` to delete from `items_fts`
+  - Backfill existing items into `items_fts`
+
+#### Scenario: FTS5 search query performance
+
+- **WHEN** performing a search query on a user with 1000+ items
+- **THEN** the system SHALL:
+  - Use FTS5 MATCH syntax with sanitized user input
+  - Append `*` to search terms for prefix matching
+  - Return results ordered by BM25 relevance rank
+  - Escape FTS5 special characters in user input
+
+### Requirement: Full-Text Search
+
+The system MUST provide fast, relevant full-text search across questions and answers.
+
+#### Scenario: Search finds items by question text
+
+- **WHEN** GET to `/api/john/items?search=deploy`
+- **THEN** the system SHALL return only items containing "deploy" in the question field, matching case-insensitively
+
+#### Scenario: Search finds items by answer text
+
+- **WHEN** GET to `/api/john/items?search=deployment`
+- **THEN** the system SHALL return items containing "deployment" in either question or answer fields, with full item details and tags
+
+#### Scenario: Search finds items by partial word
+
+- **WHEN** GET to `/api/john/items?search=kube`
+- **THEN** the system SHALL return items matching the prefix "kube*" via FTS5 prefix matching
+
+#### Scenario: Search returns empty for no matches
+
+- **WHEN** GET to `/api/john/items?search=python` and no items match
+- **THEN** the system SHALL return `{ items: [], total: 0 }` with status OK
+
+#### Scenario: Search is case-insensitive
+
+- **WHEN** searching for "bun", "BUN", or "Bun"
+- **THEN** the system SHALL return the same results regardless of case
+
+#### Scenario: Empty search returns all items
+
+- **WHEN** GET to `/api/john/items?search=` (empty string)
+- **THEN** the system SHALL return all items as if no search parameter was provided
+
+#### Scenario: Search with FTS5 special characters
+
+- **WHEN** searching for input containing FTS5 special characters like `AND`, `OR`, `"`, `*`
+- **THEN** the system SHALL escape special characters and treat them as literal text
+
+### Requirement: Tag Filtering
+
+The system MUST allow filtering items by one or more tags.
+
+#### Scenario: Filter by single tag
+
+- **WHEN** GET to `/api/john/items?tags=bun`
+- **THEN** the system SHALL return only items that have the "bun" tag, with full item details and all tags
+
+#### Scenario: Filter by multiple tags (AND operation)
+
+- **WHEN** GET to `/api/john/items?tags=bun,typescript`
+- **THEN** the system SHALL return only items that have both "bun" AND "typescript" tags, using GROUP BY/HAVING COUNT to verify all tags are present
+
+#### Scenario: Filter with no matching items
+
+- **WHEN** GET to `/api/john/items?tags=python` and no items have that tag
+- **THEN** the system SHALL return `{ items: [], total: 0 }` with status OK
+
+#### Scenario: Filter ignores nonexistent tag names
+
+- **WHEN** GET to `/api/john/items?tags=nonexistent`
+- **THEN** the system SHALL return empty results without error
+
+#### Scenario: Tag names matched case-insensitively
+
+- **WHEN** filtering by tag "Bun" and the stored tag is "bun"
+- **THEN** the system SHALL match tags case-insensitively using COLLATE NOCASE
+
+### Requirement: Combined Search and Filtering
+
+Users MUST be able to search and filter simultaneously.
+
+#### Scenario: Search text AND filter by tag
+
+- **WHEN** GET to `/api/john/items?search=deploy&tags=bun`
+- **THEN** the system SHALL return only items matching "deploy" in FTS5 AND having the "bun" tag
+
+#### Scenario: Multiple filters with pagination
+
+- **WHEN** GET to `/api/john/items?search=config&tags=bun,typescript&limit=20&offset=20`
+- **THEN** the system SHALL apply search filter, tag filters, and pagination together, returning the correct page of combined results with accurate total count
+
+### Requirement: Search Result Ranking
+
+Search results SHALL be ranked by relevance.
+
+#### Scenario: Match in question ranks higher than answer
+
+- **WHEN** searching for "bun deployment" with items matching in question vs answer
+- **THEN** the system SHALL use FTS5 BM25 ranking with question weighted higher than answer via `bm25(items_fts, 10.0, 1.0)`
+
+#### Scenario: Results without search use creation date ordering
+
+- **WHEN** listing items without a search term (tag filter only or no filters)
+- **THEN** the system SHALL order results by `created_at DESC` (most recent first)

--- a/openspec/changes/implement-search-filtering/tasks.md
+++ b/openspec/changes/implement-search-filtering/tasks.md
@@ -1,0 +1,52 @@
+## 1. Database Migration
+
+- [x] 1.1 Add migration version 5: create FTS5 virtual table `items_fts` with `content=items, content_rowid=rowid`
+- [x] 1.2 Add AFTER INSERT trigger on `items` to insert into `items_fts`
+- [x] 1.3 Add AFTER UPDATE trigger on `items` to update `items_fts`
+- [x] 1.4 Add AFTER DELETE trigger on `items` to delete from `items_fts`
+- [x] 1.5 Backfill existing items into `items_fts` within the migration
+- [x] 1.6 Test migration runs cleanly on fresh and existing databases
+
+## 2. Repository Layer
+
+- [x] 2.1 Add FTS5 input sanitization helper (escape special chars, append `*` for prefix matching)
+- [x] 2.2 Add `searchItems()` method to `ItemRepository` with optional `search`, `tags`, `limit`, `offset` parameters
+- [x] 2.3 Implement FTS5 search query with BM25 ranking (`bm25(items_fts, 10.0, 1.0)`) and user_id scoping
+- [x] 2.4 Implement tag AND filtering via GROUP BY/HAVING COUNT with case-insensitive tag name matching
+- [x] 2.5 Implement combined search + tag filter query
+- [x] 2.6 Return accurate `total` count for filtered/searched results (separate COUNT query)
+- [x] 2.7 Write integration tests for search (question match, answer match, prefix match, case-insensitive, empty, special chars)
+- [x] 2.8 Write integration tests for tag filtering (single tag, multiple tags AND, nonexistent tag, case-insensitive)
+- [x] 2.9 Write integration tests for combined search + tag filter with pagination
+
+## 3. Service Layer
+
+- [x] 3.1 Add `SearchFilters` interface with optional `search` and `tags` fields
+- [x] 3.2 Extend `ItemService.listItems()` to accept `SearchFilters` and delegate to `searchItems()` when filters are present
+- [x] 3.3 Add `filters` object to the `PaginatedItemsResult` response (`{ search: string | null, tags: string[] | null }`)
+- [x] 3.4 Write unit tests for service layer search/filter pass-through
+
+## 4. Route Layer
+
+- [x] 4.1 Add `search` and `tags` query parameters to `GET /api/:username/items` Elysia schema
+- [x] 4.2 Parse `tags` query string (comma-separated) into string array
+- [x] 4.3 Pass parsed search/tags to `itemService.listItems()`
+- [x] 4.4 Include `filters` object in JSON response
+- [x] 4.5 Write route tests for search query param, tags query param, combined filters, and empty filters
+
+## 5. Verification
+
+- [x] 5.1 Run all tests and ensure they pass
+- [x] 5.2 Run linter and fix any issues
+
+## Dependencies
+
+- Task 1 (Database) blocks Task 2 (Repository)
+- Task 2 (Repository) blocks Task 3 (Service)
+- Task 3 (Service) blocks Task 4 (Route)
+- Task 1 can be worked on immediately
+
+## Parallelizable Work
+
+- 2.1 (sanitization helper) can be done in parallel with 1.1-1.6
+- 4.1-4.2 (route schema changes) can be started in parallel with 3.1-3.4

--- a/src/server/db/migrations.ts
+++ b/src/server/db/migrations.ts
@@ -99,6 +99,38 @@ const MIGRATIONS: Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_item_tags_tag_id ON item_tags(tag_id);
     `,
   },
+  {
+    version: 5,
+    name: "create_items_fts5_table",
+    up: `
+      CREATE VIRTUAL TABLE IF NOT EXISTS items_fts USING fts5(
+        question,
+        answer,
+        content=items,
+        content_rowid=rowid
+      );
+
+      CREATE TRIGGER IF NOT EXISTS items_fts_insert AFTER INSERT ON items BEGIN
+        INSERT INTO items_fts(rowid, question, answer)
+        VALUES (new.rowid, new.question, new.answer);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS items_fts_update AFTER UPDATE ON items BEGIN
+        INSERT INTO items_fts(items_fts, rowid, question, answer)
+        VALUES ('delete', old.rowid, old.question, old.answer);
+        INSERT INTO items_fts(rowid, question, answer)
+        VALUES (new.rowid, new.question, new.answer);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS items_fts_delete AFTER DELETE ON items BEGIN
+        INSERT INTO items_fts(items_fts, rowid, question, answer)
+        VALUES ('delete', old.rowid, old.question, old.answer);
+      END;
+
+      INSERT INTO items_fts(rowid, question, answer)
+      SELECT rowid, question, answer FROM items;
+    `,
+  },
 ];
 
 export function runMigrations(): void {

--- a/src/server/repositories/item.repository.spec.ts
+++ b/src/server/repositories/item.repository.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { setupTestDatabase } from "../db/test-helpers";
 import { type CreateItemDTO, ItemRepository } from "./item.repository";
+import { TagRepository } from "./tag.repository";
 import { UserRepository } from "./user.repository";
 
 describe("ItemRepository Integration Tests", () => {
@@ -330,6 +331,201 @@ describe("ItemRepository Integration Tests", () => {
     test("returns zero for user with no items", () => {
       const count = itemRepo.countByUserId(testUserId);
       expect(count).toBe(0);
+    });
+  });
+
+  describe("searchItems", () => {
+    describe("full-text search", () => {
+      test("finds items by question text", () => {
+        itemRepo.create({ userId: testUserId, question: "How do I deploy with Bun?", answer: "Use bun build" });
+        itemRepo.create({ userId: testUserId, question: "How do I configure TypeScript?", answer: "Edit tsconfig" });
+
+        const result = itemRepo.searchItems(testUserId, { search: "deploy" });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].question).toContain("deploy");
+        expect(result.total).toBe(1);
+      });
+
+      test("finds items by answer text", () => {
+        itemRepo.create({ userId: testUserId, question: "How do I build?", answer: "Use bun build for deployment" });
+
+        const result = itemRepo.searchItems(testUserId, { search: "deployment" });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].answer).toContain("deployment");
+      });
+
+      test("finds items by prefix match", () => {
+        itemRepo.create({ userId: testUserId, question: "Kubernetes configuration" });
+
+        const result = itemRepo.searchItems(testUserId, { search: "kube" });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].question).toContain("Kubernetes");
+      });
+
+      test("search is case-insensitive", () => {
+        itemRepo.create({ userId: testUserId, question: "How do I use Bun?" });
+
+        for (const term of ["bun", "BUN", "Bun"]) {
+          const result = itemRepo.searchItems(testUserId, { search: term });
+          expect(result.items).toHaveLength(1);
+        }
+      });
+
+      test("returns empty for no matches", () => {
+        itemRepo.create({ userId: testUserId, question: "How to use Bun?" });
+
+        const result = itemRepo.searchItems(testUserId, { search: "python" });
+
+        expect(result.items).toHaveLength(0);
+        expect(result.total).toBe(0);
+      });
+
+      test("empty search returns all items", () => {
+        itemRepo.create({ userId: testUserId, question: "Q1" });
+        itemRepo.create({ userId: testUserId, question: "Q2" });
+
+        const result = itemRepo.searchItems(testUserId, { search: "" });
+
+        expect(result.items).toHaveLength(2);
+        expect(result.total).toBe(2);
+      });
+
+      test("handles FTS5 special characters safely", () => {
+        itemRepo.create({ userId: testUserId, question: "Using AND in queries" });
+
+        const result = itemRepo.searchItems(testUserId, { search: 'AND "OR" NOT*' });
+
+        expect(result.total).toBeGreaterThanOrEqual(0);
+      });
+
+      test("scopes search to user", () => {
+        const otherUser = userRepo.create({
+          username: "alice",
+          email: "alice@example.com",
+          passwordHash: "hashedpassword123",
+        });
+
+        itemRepo.create({ userId: testUserId, question: "John deploys Bun" });
+        itemRepo.create({ userId: otherUser.id, question: "Alice deploys Bun" });
+
+        const result = itemRepo.searchItems(testUserId, { search: "deploys" });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].user_id).toBe(testUserId);
+      });
+    });
+
+    describe("tag filtering", () => {
+      let tagRepo: TagRepository;
+
+      beforeEach(() => {
+        tagRepo = new TagRepository();
+      });
+
+      test("filters by single tag", () => {
+        const bunTag = tagRepo.create({ userId: testUserId, name: "bun", color: "0e8a16" });
+        const tsTag = tagRepo.create({ userId: testUserId, name: "typescript", color: "ff5722" });
+
+        const itemA = itemRepo.create({ userId: testUserId, question: "Item A" });
+        const itemB = itemRepo.create({ userId: testUserId, question: "Item B" });
+
+        tagRepo.setItemTags(itemA.id, [bunTag.id]);
+        tagRepo.setItemTags(itemB.id, [tsTag.id]);
+
+        const result = itemRepo.searchItems(testUserId, { tags: ["bun"] });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].question).toBe("Item A");
+        expect(result.total).toBe(1);
+      });
+
+      test("filters by multiple tags with AND logic", () => {
+        const bunTag = tagRepo.create({ userId: testUserId, name: "bun", color: "0e8a16" });
+        const tsTag = tagRepo.create({ userId: testUserId, name: "typescript", color: "ff5722" });
+        const deployTag = tagRepo.create({ userId: testUserId, name: "deployment", color: "2196f3" });
+
+        const itemA = itemRepo.create({ userId: testUserId, question: "Item A" });
+        const itemB = itemRepo.create({ userId: testUserId, question: "Item B" });
+        const itemC = itemRepo.create({ userId: testUserId, question: "Item C" });
+
+        tagRepo.setItemTags(itemA.id, [bunTag.id, deployTag.id]);
+        tagRepo.setItemTags(itemB.id, [bunTag.id, tsTag.id]);
+        tagRepo.setItemTags(itemC.id, [tsTag.id, deployTag.id]);
+
+        const result = itemRepo.searchItems(testUserId, { tags: ["bun", "typescript"] });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].question).toBe("Item B");
+      });
+
+      test("returns empty for nonexistent tag", () => {
+        itemRepo.create({ userId: testUserId, question: "Item A" });
+
+        const result = itemRepo.searchItems(testUserId, { tags: ["nonexistent"] });
+
+        expect(result.items).toHaveLength(0);
+        expect(result.total).toBe(0);
+      });
+
+      test("tag matching is case-insensitive", () => {
+        const tagRepo = new TagRepository();
+        const tag = tagRepo.create({ userId: testUserId, name: "Bun", color: "0e8a16" });
+        const item = itemRepo.create({ userId: testUserId, question: "Item A" });
+        tagRepo.setItemTags(item.id, [tag.id]);
+
+        const result = itemRepo.searchItems(testUserId, { tags: ["bun"] });
+
+        expect(result.items).toHaveLength(1);
+      });
+    });
+
+    describe("combined search + tag filter", () => {
+      let tagRepo: TagRepository;
+
+      beforeEach(() => {
+        tagRepo = new TagRepository();
+      });
+
+      test("applies both search and tag filter", () => {
+        const bunTag = tagRepo.create({ userId: testUserId, name: "bun", color: "0e8a16" });
+        const tsTag = tagRepo.create({ userId: testUserId, name: "typescript", color: "ff5722" });
+
+        const itemA = itemRepo.create({ userId: testUserId, question: "Deploy Bun app" });
+        const itemB = itemRepo.create({ userId: testUserId, question: "Configure Bun" });
+        const itemC = itemRepo.create({ userId: testUserId, question: "Deploy TypeScript" });
+
+        tagRepo.setItemTags(itemA.id, [bunTag.id]);
+        tagRepo.setItemTags(itemB.id, [bunTag.id]);
+        tagRepo.setItemTags(itemC.id, [tsTag.id]);
+
+        const result = itemRepo.searchItems(testUserId, { search: "deploy", tags: ["bun"] });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].question).toBe("Deploy Bun app");
+        expect(result.total).toBe(1);
+      });
+
+      test("combined filter with pagination", () => {
+        const bunTag = tagRepo.create({ userId: testUserId, name: "bun", color: "0e8a16" });
+
+        for (let i = 1; i <= 10; i++) {
+          const item = itemRepo.create({ userId: testUserId, question: `Deploy step ${i}` });
+          tagRepo.setItemTags(item.id, [bunTag.id]);
+        }
+
+        const result = itemRepo.searchItems(testUserId, {
+          search: "deploy",
+          tags: ["bun"],
+          limit: 3,
+          offset: 0,
+        });
+
+        expect(result.items).toHaveLength(3);
+        expect(result.total).toBe(10);
+      });
     });
   });
 });

--- a/src/server/repositories/item.repository.ts
+++ b/src/server/repositories/item.repository.ts
@@ -4,6 +4,16 @@ import { BaseRepository } from "./base.repository";
 
 export type { Item };
 
+export function sanitizeFtsQuery(input: string): string {
+  const escaped = input
+    .replace(/["\-*()^~:]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (escaped === "") return '""';
+  const terms = escaped.split(" ").filter(Boolean);
+  return terms.map((term) => `"${term}"*`).join(" ");
+}
+
 export interface CreateItemDTO {
   userId: string;
   question: string;
@@ -18,6 +28,11 @@ export interface UpdateItemDTO {
 export interface PaginationOptions {
   limit?: number;
   offset?: number;
+}
+
+export interface SearchOptions extends PaginationOptions {
+  search?: string;
+  tags?: string[];
 }
 
 export interface PaginatedResult<T> {
@@ -93,6 +108,136 @@ export class ItemRepository extends BaseRepository<Item> {
     db.run(`UPDATE items SET ${updates.join(", ")} WHERE id = ?`, values);
 
     return this.findById(id);
+  }
+
+  searchItems(userId: string, options: SearchOptions = {}): PaginatedResult<Item> {
+    const { limit = 50, offset = 0, search, tags } = options;
+    const hasSearch = search !== undefined && search.trim() !== "";
+    const hasTags = tags !== undefined && tags.length > 0;
+
+    if (!hasSearch && !hasTags) {
+      return this.findByUserId(userId, { limit, offset });
+    }
+
+    if (hasSearch && hasTags) {
+      return this.searchWithTags(userId, search.trim(), tags, limit, offset);
+    }
+
+    if (hasSearch) {
+      return this.searchOnly(userId, search.trim(), limit, offset);
+    }
+
+    return this.filterByTags(userId, tags as string[], limit, offset);
+  }
+
+  private searchOnly(userId: string, search: string, limit: number, offset: number): PaginatedResult<Item> {
+    const sanitized = sanitizeFtsQuery(search);
+    const params: (string | number)[] = [userId, sanitized];
+
+    const countResult = db
+      .query<{ count: number }, (string | number)[]>(
+        `SELECT COUNT(*) as count FROM items
+         JOIN items_fts ON items.rowid = items_fts.rowid
+         WHERE items.user_id = ? AND items_fts MATCH ?`,
+      )
+      .get(...params);
+    const total = countResult?.count ?? 0;
+
+    const items = db
+      .query<Item, (string | number)[]>(
+        `SELECT items.* FROM items
+         JOIN items_fts ON items.rowid = items_fts.rowid
+         WHERE items.user_id = ? AND items_fts MATCH ?
+         ORDER BY bm25(items_fts, 10.0, 1.0)
+         LIMIT ? OFFSET ?`,
+      )
+      .all(userId, sanitized, limit, offset);
+
+    return { items, total };
+  }
+
+  private filterByTags(userId: string, tags: string[], limit: number, offset: number): PaginatedResult<Item> {
+    const placeholders = tags.map(() => "?").join(", ");
+    const params: (string | number)[] = [userId, ...tags, tags.length];
+
+    const countResult = db
+      .query<{ count: number }, (string | number)[]>(
+        `SELECT COUNT(*) as count FROM (
+           SELECT items.id FROM items
+           JOIN item_tags ON items.id = item_tags.item_id
+           JOIN tags ON item_tags.tag_id = tags.id
+           WHERE items.user_id = ? AND tags.name IN (${placeholders})
+           GROUP BY items.id
+           HAVING COUNT(DISTINCT tags.id) = ?
+         )`,
+      )
+      .get(...params);
+    const total = countResult?.count ?? 0;
+
+    const items = db
+      .query<Item, (string | number)[]>(
+        `SELECT items.* FROM items
+         JOIN item_tags ON items.id = item_tags.item_id
+         JOIN tags ON item_tags.tag_id = tags.id
+         WHERE items.user_id = ? AND tags.name IN (${placeholders})
+         GROUP BY items.id
+         HAVING COUNT(DISTINCT tags.id) = ?
+         ORDER BY items.created_at DESC
+         LIMIT ? OFFSET ?`,
+      )
+      .all(...params, limit, offset);
+
+    return { items, total };
+  }
+
+  private searchWithTags(
+    userId: string,
+    search: string,
+    tags: string[],
+    limit: number,
+    offset: number,
+  ): PaginatedResult<Item> {
+    const sanitized = sanitizeFtsQuery(search);
+    const placeholders = tags.map(() => "?").join(", ");
+
+    const matchedIdsParams: (string | number)[] = [userId, sanitized];
+    const matchedIdsSql = `SELECT items.id, items.rowid AS item_rowid FROM items
+      JOIN items_fts ON items.rowid = items_fts.rowid
+      WHERE items.user_id = ? AND items_fts MATCH ?`;
+
+    const tagFilterParams: (string | number)[] = [...matchedIdsParams, ...tags, tags.length];
+    const countResult = db
+      .query<{ count: number }, (string | number)[]>(
+        `SELECT COUNT(*) as count FROM (
+           SELECT matched.id FROM (${matchedIdsSql}) AS matched
+           JOIN item_tags ON matched.id = item_tags.item_id
+           JOIN tags ON item_tags.tag_id = tags.id
+           WHERE tags.name IN (${placeholders})
+           GROUP BY matched.id
+           HAVING COUNT(DISTINCT tags.id) = ?
+         )`,
+      )
+      .get(...tagFilterParams);
+    const total = countResult?.count ?? 0;
+
+    const items = db
+      .query<Item, (string | number)[]>(
+        `SELECT items.* FROM items
+         JOIN items_fts ON items.rowid = items_fts.rowid
+         WHERE items.user_id = ? AND items_fts MATCH ?
+           AND items.id IN (
+             SELECT it_sub.item_id FROM item_tags it_sub
+             JOIN tags t_sub ON it_sub.tag_id = t_sub.id
+             WHERE t_sub.name IN (${placeholders})
+             GROUP BY it_sub.item_id
+             HAVING COUNT(DISTINCT t_sub.id) = ?
+           )
+         ORDER BY bm25(items_fts, 10.0, 1.0)
+         LIMIT ? OFFSET ?`,
+      )
+      .all(userId, sanitized, ...tags, tags.length, limit, offset);
+
+    return { items, total };
   }
 
   countByUserId(userId: string): number {

--- a/src/server/routes/item.routes.spec.ts
+++ b/src/server/routes/item.routes.spec.ts
@@ -6,7 +6,14 @@ import type { ItemError, ItemWithTags } from "../services/item.service";
 
 type ItemResult = { success: true; data: ItemWithTags } | { success: false; error: ItemError };
 type ListResult =
-  | { success: true; data: { items: ItemWithTags[]; total: number } }
+  | {
+      success: true;
+      data: {
+        items: ItemWithTags[];
+        total: number;
+        filters: { search: string | null; tags: string[] | null };
+      };
+    }
   | { success: false; error: ItemError };
 type DeleteResult = { success: true; data: { deleted: true } } | { success: false; error: ItemError };
 
@@ -104,18 +111,28 @@ const mockSessionItemService = {
     }
     return createSuccessResult(item);
   }),
-  listItems: mock((username: string, pagination: { limit?: number; offset?: number } = {}): ListResult => {
-    const user = testUsers.get(username);
-    if (!user) {
-      return createErrorResult("USER_NOT_FOUND", "User not found");
-    }
-    const userItems = Array.from(testItems.values()).filter((i) => i.user_id === user.id);
-    const { limit = 50, offset = 0 } = pagination;
-    return createSuccessResult({
-      items: userItems.slice(offset, offset + limit),
-      total: userItems.length,
-    });
-  }),
+  listItems: mock(
+    (
+      username: string,
+      pagination: { limit?: number; offset?: number } = {},
+      filters: { search?: string; tags?: string[] } = {},
+    ): ListResult => {
+      const user = testUsers.get(username);
+      if (!user) {
+        return createErrorResult("USER_NOT_FOUND", "User not found");
+      }
+      const userItems = Array.from(testItems.values()).filter((i) => i.user_id === user.id);
+      const { limit = 50, offset = 0 } = pagination;
+      return createSuccessResult({
+        items: userItems.slice(offset, offset + limit),
+        total: userItems.length,
+        filters: {
+          search: filters.search?.trim() || null,
+          tags: filters.tags && filters.tags.length > 0 ? filters.tags : null,
+        },
+      });
+    },
+  ),
 };
 
 const mockItemService = mockSessionItemService;
@@ -952,6 +969,66 @@ describe("Item Routes", () => {
       const listData = await listRes.json();
       expect(listData.items[0].tags).toHaveLength(1);
       expect(listData.items[0].tags[0].name).toBe("bun");
+    });
+  });
+
+  describe("Search and Filter Query Params", () => {
+    test("passes search param and returns filters in response", async () => {
+      const { token } = await registerAndLogin("john", "john@example.com");
+
+      await app.handle(
+        new Request("http://localhost/api/john/items", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...authHeader(token),
+          },
+          body: JSON.stringify({ question: "Deploy with Bun" }),
+        }),
+      );
+
+      const res = await app.handle(new Request("http://localhost/api/john/items?search=deploy"));
+
+      expect(res.status).toBe(StatusCodes.OK);
+      const data = await res.json();
+      expect(data.filters).toBeDefined();
+      expect(data.filters.search).toBe("deploy");
+      expect(data.filters.tags).toBeNull();
+    });
+
+    test("passes tags param and returns filters in response", async () => {
+      await registerAndLogin("john", "john@example.com");
+
+      const res = await app.handle(new Request("http://localhost/api/john/items?tags=bun,typescript"));
+
+      expect(res.status).toBe(StatusCodes.OK);
+      const data = await res.json();
+      expect(data.filters).toBeDefined();
+      expect(data.filters.search).toBeNull();
+      expect(data.filters.tags).toEqual(["bun", "typescript"]);
+    });
+
+    test("passes combined search and tags params", async () => {
+      await registerAndLogin("john", "john@example.com");
+
+      const res = await app.handle(new Request("http://localhost/api/john/items?search=deploy&tags=bun"));
+
+      expect(res.status).toBe(StatusCodes.OK);
+      const data = await res.json();
+      expect(data.filters.search).toBe("deploy");
+      expect(data.filters.tags).toEqual(["bun"]);
+    });
+
+    test("returns null filters when no search/tags params", async () => {
+      await registerAndLogin("john", "john@example.com");
+
+      const res = await app.handle(new Request("http://localhost/api/john/items"));
+
+      expect(res.status).toBe(StatusCodes.OK);
+      const data = await res.json();
+      expect(data.filters).toBeDefined();
+      expect(data.filters.search).toBeNull();
+      expect(data.filters.tags).toBeNull();
     });
   });
 });

--- a/src/server/routes/item.routes.ts
+++ b/src/server/routes/item.routes.ts
@@ -14,7 +14,15 @@ export const itemRoutes = new Elysia({ prefix: "/:username/items" })
       const limit = Math.min(Math.max(Number.isFinite(parsedLimit) ? parsedLimit : 50, 1), 100);
       const offset = Math.max(Number.isFinite(parsedOffset) ? parsedOffset : 0, 0);
 
-      const result = itemService.listItems(params.username, { limit, offset });
+      const search = query.search || undefined;
+      const tags = query.tags
+        ? query.tags
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : undefined;
+
+      const result = itemService.listItems(params.username, { limit, offset }, { search, tags });
 
       if (!result.success) {
         if (result.error.code === "USER_NOT_FOUND") {
@@ -29,7 +37,7 @@ export const itemRoutes = new Elysia({ prefix: "/:username/items" })
         };
       }
 
-      return { items: result.data.items, total: result.data.total };
+      return { items: result.data.items, total: result.data.total, filters: result.data.filters };
     },
     {
       params: t.Object({
@@ -38,6 +46,8 @@ export const itemRoutes = new Elysia({ prefix: "/:username/items" })
       query: t.Object({
         limit: t.Optional(t.String()),
         offset: t.Optional(t.String()),
+        search: t.Optional(t.String()),
+        tags: t.Optional(t.String()),
       }),
     },
   )

--- a/src/server/services/item.service.spec.ts
+++ b/src/server/services/item.service.spec.ts
@@ -57,6 +57,16 @@ const mockItemRepository = {
   delete: mock((id: string) => {
     testItems.delete(id);
   }),
+  searchItems: mock(
+    (userId: string, options: { limit?: number; offset?: number; search?: string; tags?: string[] } = {}) => {
+      const userItems = Array.from(testItems.values()).filter((i) => i.user_id === userId);
+      const { limit = 50, offset = 0 } = options;
+      return {
+        items: userItems.slice(offset, offset + limit),
+        total: userItems.length,
+      };
+    },
+  ),
 };
 
 mock.module("../repositories", () => ({
@@ -348,7 +358,7 @@ describe("ItemService", () => {
   });
 
   describe("listItems", () => {
-    test("returns paginated items with tags", () => {
+    test("returns paginated items with tags and filters", () => {
       const user = createTestUser("john");
       const mockTagService = createMockTagService(user.id);
       const itemService = new ItemService(user.id, mockTagService as unknown as TagService);
@@ -363,6 +373,7 @@ describe("ItemService", () => {
 
       expect(result.data.items).toHaveLength(2);
       expect(result.data.total).toBe(2);
+      expect(result.data.filters).toEqual({ search: null, tags: null });
     });
 
     test("returns user not found error for non-existent user", () => {
@@ -394,6 +405,68 @@ describe("ItemService", () => {
 
       expect(result.data.items).toHaveLength(2);
       expect(result.data.total).toBe(5);
+    });
+
+    test("passes search filter and returns it in response", () => {
+      const user = createTestUser("john");
+      const mockTagService = createMockTagService(user.id);
+      const itemService = new ItemService(user.id, mockTagService as unknown as TagService);
+
+      itemService.createItem({ question: "Q1" });
+
+      const result = itemService.listItems("john", {}, { search: "Q1" });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      expect(result.data.filters.search).toBe("Q1");
+      expect(result.data.filters.tags).toBeNull();
+    });
+
+    test("passes tags filter and returns it in response", () => {
+      const user = createTestUser("john");
+      const mockTagService = createMockTagService(user.id);
+      const itemService = new ItemService(user.id, mockTagService as unknown as TagService);
+
+      itemService.createItem({ question: "Q1" });
+
+      const result = itemService.listItems("john", {}, { tags: ["bun", "typescript"] });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      expect(result.data.filters.search).toBeNull();
+      expect(result.data.filters.tags).toEqual(["bun", "typescript"]);
+    });
+
+    test("empty search string results in null filter", () => {
+      const user = createTestUser("john");
+      const mockTagService = createMockTagService(user.id);
+      const itemService = new ItemService(user.id, mockTagService as unknown as TagService);
+
+      itemService.createItem({ question: "Q1" });
+
+      const result = itemService.listItems("john", {}, { search: "  " });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      expect(result.data.filters.search).toBeNull();
+    });
+
+    test("empty tags array results in null filter", () => {
+      const user = createTestUser("john");
+      const mockTagService = createMockTagService(user.id);
+      const itemService = new ItemService(user.id, mockTagService as unknown as TagService);
+
+      itemService.createItem({ question: "Q1" });
+
+      const result = itemService.listItems("john", {}, { tags: [] });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      expect(result.data.filters.tags).toBeNull();
     });
   });
 

--- a/src/server/services/item.service.ts
+++ b/src/server/services/item.service.ts
@@ -9,9 +9,18 @@ export interface ItemWithTags extends Item {
   tags: Tag[];
 }
 
+export interface SearchFilters {
+  search?: string;
+  tags?: string[];
+}
+
 export interface PaginatedItemsResult {
   items: ItemWithTags[];
   total: number;
+  filters: {
+    search: string | null;
+    tags: string[] | null;
+  };
 }
 
 export interface CreateItemInput {
@@ -130,14 +139,22 @@ export class ItemService {
     };
   }
 
-  listItems(username: string, pagination: { limit?: number; offset?: number } = {}): Result<PaginatedItemsResult> {
+  listItems(
+    username: string,
+    pagination: { limit?: number; offset?: number } = {},
+    filters: SearchFilters = {},
+  ): Result<PaginatedItemsResult> {
     const user = userService.findByUsername(username);
     if (!user) {
       return createError("USER_NOT_FOUND", "User not found");
     }
 
     const { limit = 50, offset = 0 } = pagination;
-    const result = itemRepository.findByUserId(user.id, { limit, offset });
+    const hasFilters = (filters.search && filters.search.trim() !== "") || (filters.tags && filters.tags.length > 0);
+
+    const result = hasFilters
+      ? itemRepository.searchItems(user.id, { limit, offset, search: filters.search, tags: filters.tags })
+      : itemRepository.findByUserId(user.id, { limit, offset });
 
     const itemsWithTags = result.items.map((item) => ({
       ...item,
@@ -146,7 +163,14 @@ export class ItemService {
 
     return {
       success: true,
-      data: { items: itemsWithTags, total: result.total },
+      data: {
+        items: itemsWithTags,
+        total: result.total,
+        filters: {
+          search: filters.search?.trim() || null,
+          tags: filters.tags && filters.tags.length > 0 ? filters.tags : null,
+        },
+      },
     };
   }
 


### PR DESCRIPTION
Add FTS5 full-text search and tag-based AND filtering to the items listing endpoint. Includes SQLite FTS5 virtual table with sync triggers, BM25 ranking, input sanitization, combined search+tag queries, and pagination support across all filter combinations.

- Add migration v5: FTS5 virtual table with content sync triggers
- Add sanitizeFtsQuery helper and searchItems repository methods
- Extend ItemService.listItems with SearchFilters support
- Add search/tags query params to GET /:username/items route
- Add filters object to paginated response
- Add 22 new tests (14 repository, 4 service, 4 route)